### PR TITLE
Fix android downloads for modern unity (2017+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,5 @@ MigrationBackup/
 
 Output
 /UDGB.zip
+
+packages/

--- a/ArchiveHandler.cs
+++ b/ArchiveHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -13,11 +13,17 @@ namespace UDGB
         private static AutoResetEvent ResetEvent_Output = new AutoResetEvent(false);
         private static AutoResetEvent ResetEvent_Error = new AutoResetEvent(false);
 
-        internal static void CreateZip(string input_folder, string output_file)
+        internal static void CreateZip(string input_folder, string output_file, bool cleanup = false)
         {
             if (File.Exists(output_file))
                 File.Delete(output_file);
             ZipFile.CreateFromDirectory(input_folder, output_file);
+
+            if (cleanup)
+            {
+                if (Directory.Exists(input_folder))
+                    Directory.Delete(input_folder, true);
+            }
         }
 
         internal static bool ExtractFiles(string output_path, string archive_path, string internal_path, bool keep_file_path = false)

--- a/UDGB.csproj
+++ b/UDGB.csproj
@@ -43,6 +43,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="VersionUtilities, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\AssetRipper.VersionUtilities.1.0.1\lib\net40\VersionUtilities.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArchiveHandler.cs" />
@@ -54,6 +57,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Icon.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UnityVersion.cs
+++ b/UnityVersion.cs
@@ -10,15 +10,12 @@ namespace UDGB
         internal static List<UnityVersion> VersionTbl = new List<UnityVersion>();
         internal static string UnityURL = "https://unity3d.com/get-unity/download/archive";
         internal _UnityVersion Version = _UnityVersion.MinVersion;
-        // internal string VersionStr = null;
-        // internal string FullVersionStr = null;
         internal string DownloadURL = null;
         internal string HashStr = null;
         internal bool UsePayloadExtraction = false;
         private static string QuoteStr = "\"";
 
         [Obsolete("VersionStr is deprecated, please use Version.ToStringWithoutType() instead.")]
-
         internal string VersionStr => Version.ToStringWithoutType();
         [Obsolete("FullVersionStr is deprecated, please use Version.ToString() instead.")]
         internal string FullVersionStr => Version.ToString();
@@ -26,20 +23,6 @@ namespace UDGB
         internal UnityVersion(string fullversion, string downloadurl)
         {
             Version = _UnityVersion.Parse(fullversion);
-            // VersionStr = version;
-            // FullVersionStr = fullversion;
-            // DownloadURL = downloadurl;
-            //
-            // string[] versiontbl = version.Split('.');
-            // for (int i = 0; i < versiontbl.Length; i++)
-            // {
-            //     int output = 0;
-            //     if (!int.TryParse(versiontbl[i], out output))
-            //         continue;
-            //     Version[i] = output;
-            // }
-            // Version.ToString()
-
 
             string[] downloadurl_splices = downloadurl.Split('/');
             if (Version < _UnityVersion.Parse("5.3.99") || downloadurl_splices[4].EndsWith(".exe"))

--- a/UnityVersion.cs
+++ b/UnityVersion.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+
+using _UnityVersion = AssetRipper.VersionUtilities.UnityVersion;
 
 namespace UDGB
 {
@@ -6,47 +9,53 @@ namespace UDGB
     {
         internal static List<UnityVersion> VersionTbl = new List<UnityVersion>();
         internal static string UnityURL = "https://unity3d.com/get-unity/download/archive";
-        internal int[] Version = { 0, 0, 0, 0 };
-        internal string VersionStr = null;
-        internal string FullVersionStr = null;
+        internal _UnityVersion Version = _UnityVersion.MinVersion;
+        // internal string VersionStr = null;
+        // internal string FullVersionStr = null;
         internal string DownloadURL = null;
         internal string HashStr = null;
         internal bool UsePayloadExtraction = false;
         private static string QuoteStr = "\"";
 
-        internal UnityVersion(string version, string fullversion, string downloadurl)
-        {
-            VersionStr = version;
-            FullVersionStr = fullversion;
-            DownloadURL = downloadurl;
+        [Obsolete("VersionStr is deprecated, please use Version.ToStringWithoutType() instead.")]
 
-            string[] versiontbl = version.Split('.');
-            for (int i = 0; i < versiontbl.Length; i++)
-            {
-                int output = 0;
-                if (!int.TryParse(versiontbl[i], out output))
-                    continue;
-                Version[i] = output;
-            }
+        internal string VersionStr => Version.ToStringWithoutType();
+        [Obsolete("FullVersionStr is deprecated, please use Version.ToString() instead.")]
+        internal string FullVersionStr => Version.ToString();
+
+        internal UnityVersion(string fullversion, string downloadurl)
+        {
+            Version = _UnityVersion.Parse(fullversion);
+            // VersionStr = version;
+            // FullVersionStr = fullversion;
+            // DownloadURL = downloadurl;
+            //
+            // string[] versiontbl = version.Split('.');
+            // for (int i = 0; i < versiontbl.Length; i++)
+            // {
+            //     int output = 0;
+            //     if (!int.TryParse(versiontbl[i], out output))
+            //         continue;
+            //     Version[i] = output;
+            // }
+            // Version.ToString()
 
 
             string[] downloadurl_splices = downloadurl.Split('/');
-            if ((Version[0] < 5) 
-                || ((Version[0] == 5) && (Version[1] < 3))
-                || downloadurl_splices[4].EndsWith(".exe"))
+            if (Version < _UnityVersion.Parse("5.3.99") || downloadurl_splices[4].EndsWith(".exe"))
             {
-                Logger.DebugMsg($"{VersionStr} - {DownloadURL}");
+                Logger.DebugMsg($"{Version.ToStringWithoutType()} - {DownloadURL}");
                 return;
             }
 
             UsePayloadExtraction = true;
             HashStr = downloadurl_splices[4];
             DownloadURL = $"https://download.unity3d.com/download_unity/{HashStr}/MacEditorTargetInstaller/UnitySetup-Windows-";
-            if (Version[0] >= 2018)
+            if (Version >= _UnityVersion.Parse("2018.0.0"))
                 DownloadURL += "Mono-";
-            DownloadURL += $"Support-for-Editor-{FullVersionStr}.pkg";
+            DownloadURL += $"Support-for-Editor-{Version.ToString()}.pkg";
 
-            Logger.DebugMsg($"{VersionStr} - {HashStr} - {DownloadURL}");
+            Logger.DebugMsg($"{Version.ToStringWithoutType()} - {HashStr} - {DownloadURL}");
         }
 
         internal static void Refresh()
@@ -120,7 +129,7 @@ namespace UDGB
                 if (found_version.Contains("f"))
                     found_version = found_version.Substring(0, found_version.IndexOf("f"));
 
-                VersionTbl.Add(new UnityVersion(found_version, fullversion, found_url));
+                VersionTbl.Add(new UnityVersion(fullversion, found_url));
             }
             
             VersionTbl.Reverse();

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AssetRipper.VersionUtilities" version="1.0.1" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
- Android respect `UnityVersion.UsePayloadExtraction`
- Added .pkg downloads
- Switched unity version checking to `AssetRipper.UnityVersion`
- Fixed bug where `7z x ...` couldn't overwrite files in `tmp`

I haven't fully tested the changes yet. Currently running `--all;android`.
I will comment once I test normal mode.